### PR TITLE
File segmentation using an overlap seg to split

### DIFF
--- a/scripts/base/chunk_ccs.py
+++ b/scripts/base/chunk_ccs.py
@@ -19,6 +19,7 @@ parser.add_argument("desc_cvname")
 parser.add_argument("seg_cvname")
 parser.add_argument("storagestr")
 parser.add_argument("--storagedir", default=None, help="file storage dir")
+parser.add_argument("--overlap_seg", default=None)
 
 # Processing Parameters
 parser.add_argument("cc_thresh", type=float)

--- a/scripts/base/merge_ccs.py
+++ b/scripts/base/merge_ccs.py
@@ -21,6 +21,7 @@ parser.add_argument("size_thr", type=int)
 parser.add_argument("--max_face_shape", type=int,
                     nargs="+", default=(1024, 1024))
 parser.add_argument("--timing_tag", default=None)
+parser.add_argument("--enforce_overlaps", action="store_true")
 
 args = parser.parse_args()
 print(vars(args))

--- a/scripts/generation/chunk_ccs.py
+++ b/scripts/generation/chunk_ccs.py
@@ -30,6 +30,7 @@ def main(
         num_merge_tasks=config["nummergetasks"],
         bboxes=bboxes,
         configfilename=config["filename"],
+        overlap_seg=config["overlap_seg"],
     )
 
 

--- a/scripts/generation/chunk_ccs.py
+++ b/scripts/generation/chunk_ccs.py
@@ -1,11 +1,8 @@
 """Task generation script for chunk connected components."""
 from __future__ import annotations
 
-import argparse
-from typing import Optional
-
-from taskqueue import TaskQueue
-from kombuworker import taskqueueworker as tqw
+from typing import Optional, Generator
+from functools import partial
 
 from synaptor import BBox3d
 from synaptor.cloud import task_creation as tc

--- a/scripts/generation/merge_ccs.py
+++ b/scripts/generation/merge_ccs.py
@@ -20,7 +20,10 @@ def main(
     config = parser.parse(configfilename)
 
     task = tc.create_merge_ccs_task(
-        config["storagestrs"][0], config["szthresh"], config["maxfaceshape"]
+        config["storagestrs"][0],
+        config["szthresh"],
+        config["maxfaceshape"],
+        enforce_overlaps=config["overlap_seg"] is not None,
     )
 
     queueurl = parser.parse_opt_if_not_passed("queueurl", queueurl, configfilename)

--- a/synaptor/cloud/parser.py
+++ b/synaptor/cloud/parser.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import re
 import json
 import warnings
-from typing import Optional, Union
+from typing import Optional
 from configparser import ConfigParser
 
 from .. import io

--- a/synaptor/cloud/parser.py
+++ b/synaptor/cloud/parser.py
@@ -38,6 +38,7 @@ def parse(filename: str):
     parsed["tempoutput"] = section.get("tempoutput", parsed["output"])
     parsed["baseseg"] = section.get("baseseg", None)
     parsed["image"] = section.get("image", None)
+    parsed["overlap_seg"] = section.get("overlap_seg", None)
 
     # [Dimensions]
     section = to_parse["Dimensions"]

--- a/synaptor/cloud/task_creation.py
+++ b/synaptor/cloud/task_creation.py
@@ -31,7 +31,8 @@ def create_connected_component_tasks(
     parallel: Optional[int] = 1,
     num_merge_tasks: Optional[int] = 1,
     bboxes: Optional[list[Bbox]] = None,
-    configfilename: Optional[str] = None
+    configfilename: Optional[str] = None,
+    overlap_seg: Optional[str] = None,
 ) -> Iterable:
     """Returns a iterator of partial cc_tasks."""
     print(bboxes)
@@ -64,17 +65,25 @@ def create_connected_component_tasks(
                     resolution=resolution,
                     storagedir=storagedir,
                     configfilename=configfilename,
+                    overlap_seg=overlap_seg,
                 )
 
     return ConnectedComponentsTaskIterator()
 
 
 def create_merge_ccs_task(
-    storagestr: str, size_thr: int, max_face_shape: tuple[int, int],
+    storagestr: str,
+    size_thr: int,
+    max_face_shape: tuple[int, int],
+    enforce_overlaps: Optional[bool] = False,
 ) -> partial:
     """Wraps a merge_ccs task in a partial fn."""
     return partial(
-        tasks_w_io.merge_ccs_task, storagestr, size_thr, max_face_shape=max_face_shape
+        tasks_w_io.merge_ccs_task,
+        storagestr,
+        size_thr,
+        max_face_shape=max_face_shape,
+        enforce_overlaps=enforce_overlaps,
     )
 
 

--- a/synaptor/proc/tasks_w_io.py
+++ b/synaptor/proc/tasks_w_io.py
@@ -41,6 +41,7 @@ def cc_task(
     num_merge_tasks: Optional[int] = 100,
     timing_tag: Optional[str] = None,
     configfilename: Optional[str] = None,
+    overlap_seg: Optional[str] = None,
 ) -> None:
     """Atomic connected components task with standard IO."""
     start_time = time.time()
@@ -80,8 +81,18 @@ def cc_task(
         parallel=parallel,
     )
 
+    if overlap_seg is not None:
+        overlap_seg_data = timed(
+            f"Reading overlap segmentation data from: {overlap_seg}",
+            io.read_cloud_volume_chunk,
+            overlap_seg,
+            chunk_bounds,
+            resolution=resolution,
+            parallel=parallel,
+        )
+
     ccs, continuations, seg_info = tasks.cc_task(
-        desc_vol, cc_thresh, sz_thresh, offset=chunk_begin
+        desc_vol, cc_thresh, sz_thresh, offset=chunk_begin, overlap_seg=overlap_seg_data
     )
 
     # Parsing provenance information for CirrusVolume
@@ -185,6 +196,7 @@ def merge_ccs_task(
     size_thr: int,
     max_face_shape: tuple[int, int],
     timing_tag: Optional[str] = None,
+    enforce_overlaps: Optional[bool] = False,
 ) -> None:
     """Merging atomic connected component results without parallelism."""
     start_time = time.time()
@@ -201,7 +213,11 @@ def merge_ccs_task(
 
     # Processing
     cons_cleft_info, chunk_id_maps = tasks.merge_ccs_task(
-        cont_info_arr, cleft_info_arr, size_thr, max_face_shape
+        cont_info_arr,
+        cleft_info_arr,
+        size_thr,
+        max_face_shape,
+        enforce_overlaps=enforce_overlaps,
     )
 
     timed(


### PR DESCRIPTION
Allows file segmentation to use an overlap segmentation to split output that spans the boundaries of multiple segments.