### PR TITLE
fix: db ccs chunk overlap tracking

### DIFF
--- a/scripts/generation/seg_graph_ccs.py
+++ b/scripts/generation/seg_graph_ccs.py
@@ -21,7 +21,9 @@ def main(
     config = parser.parse(configfilename)
 
     task = tc.create_seg_graph_cc_task(
-        config["storagestrs"][0], config["nummergetasks"]
+        config["storagestrs"][0],
+        config["nummergetasks"],
+        enforce_overlaps=config["overlap_seg"] is not None,
     )
 
     queueurl = parser.parse_opt_if_not_passed("queueurl", queueurl, configfilename)

--- a/synaptor/cloud/task_creation.py
+++ b/synaptor/cloud/task_creation.py
@@ -113,8 +113,15 @@ def create_match_contins_tasks(
     return MatchContinsTaskIterator()
 
 
-def create_seg_graph_cc_task(storagestr: str, num_merge_tasks: int) -> partial:
-    return partial(tasks_w_io.seg_graph_cc_task, storagestr, num_merge_tasks)
+def create_seg_graph_cc_task(
+    storagestr: str, num_merge_tasks: int, enforce_overlaps: bool = False
+) -> partial:
+    return partial(
+        tasks_w_io.seg_graph_cc_task,
+        storagestr,
+        num_merge_tasks,
+        enforce_overlaps=enforce_overlaps,
+    )
 
 
 def create_index_seg_map_task(storagestr: str) -> partial:

--- a/synaptor/io/backends/cloudvolume.py
+++ b/synaptor/io/backends/cloudvolume.py
@@ -67,11 +67,10 @@ def write_cloud_volume_chunk(
         sources=sources,
         motivation=motivation,
         process=thisprocess,
+        bounded=False,
+        fill_missing=True,
+        delete_black_uploads=True,
     )
-
-    # ensuring that we always read something for non-aligned writes
-    cv.fill_missing = True
-    cv.bounded = False
 
     cv[bbox.index()] = data.astype(cv.dtype)
 
@@ -92,11 +91,12 @@ def init_seg_volume(
         1,  # num_channels
         "segmentation",  # layer_type
         "uint32",  # data_type
-        "raw",  # encoding
+        "compressed_segmentation",  # encoding
         resolution,
         offset,
         vol_shape,
         chunk_size=chunk_size,
+        compressed_segmentation_block_size=(8, 8, 8),
     )
 
     thisprocess = thisProcess(parameters)
@@ -107,7 +107,7 @@ def init_seg_volume(
         info=info,
         sources=sources,
         motivation=motivation,
-        process=thisprocess
+        process=thisprocess,
     )
 
     cv.commit_info()

--- a/synaptor/proc/io/__init__.py
+++ b/synaptor/proc/io/__init__.py
@@ -40,6 +40,7 @@ from . import overlap
 from .overlap import read_chunk_overlap_mat, write_chunk_overlap_mat
 from .overlap import read_all_overlap_mats
 from .overlap import read_max_overlaps, write_max_overlaps
+from .overlap import read_seg_overlap_map
 
 from . import timing
 from .timing import read_task_timing, write_task_timing

--- a/synaptor/proc/io/initdb.py
+++ b/synaptor/proc/io/initdb.py
@@ -109,7 +109,9 @@ def init_seg_table(metadata, tablename, segid_colname=cn.seg_id, chunked=True):
                Column(cn.bbox_bz, Integer),
                Column(cn.bbox_ex, Integer),
                Column(cn.bbox_ey, Integer),
-               Column(cn.bbox_ez, Integer)]
+               Column(cn.bbox_ez, Integer),
+               # Overlap seg id - None if no overlap or not tracked
+               Column(cn.ovl_segid, BigInteger, nullable=True)]
 
     if chunked:
         # Chunk id - None if merged across chunks

--- a/synaptor/proc/io/overlap.py
+++ b/synaptor/proc/io/overlap.py
@@ -119,6 +119,21 @@ def make_empty_df():
     return df.set_index(cn.seg_id)
 
 
+def read_seg_overlap_map(proc_url):
+    """Reads the mapping from global segment ID to overlap seg ID from chunk_segs."""
+    assert io.is_db_url(proc_url), "Not implemented for file IO"
+
+    metadata = io.open_db_metadata(proc_url)
+    chunk_segs = metadata.tables["chunk_segs"]
+
+    statement = select([chunk_segs.c["id"], chunk_segs.c[cn.ovl_segid]]).where(
+        chunk_segs.c[cn.ovl_segid].isnot(None)
+    )
+
+    df = io.read_db_dframe(proc_url, statement)
+    return dict(zip(df["id"], df[cn.ovl_segid]))
+
+
 def read_max_overlaps(proc_url):
     """
     Reads the mapping from segment to base segment of maximal overlap

--- a/synaptor/proc/io/seginfo.py
+++ b/synaptor/proc/io/seginfo.py
@@ -53,6 +53,8 @@ def write_chunk_seg_info(dframe, proc_url, chunk_bounds):
 def prep_chunk_seg_info(dframe, chunk_bounds):
     chunk_tag = io.fname_chunk_tag(chunk_bounds)
     to_write = dframe.reset_index()[SEG_INFO_COLUMNS].copy()
+    if cn.ovl_segid in dframe.columns:
+        to_write[cn.ovl_segid] = dframe[cn.ovl_segid].values
     to_write[cn.chunk_tag] = chunk_tag
 
     return to_write, CHUNKED_TABLENAME

--- a/synaptor/proc/tasks.py
+++ b/synaptor/proc/tasks.py
@@ -168,7 +168,11 @@ def match_continuations_task(
     return graph_edges
 
 
-def seg_graph_cc_task(graph_edges, num_merge_tasks, all_ids):
+def seg_graph_cc_task(graph_edges, num_merge_tasks, all_ids, overlap_map=None):
+    if overlap_map is not None:
+        graph_edges = [(a, b) for a, b in graph_edges
+                       if overlap_map.get(a) == overlap_map.get(b)]
+
     ccs = timed(
         "Finding connected components", utils.find_connected_components, graph_edges
     )

--- a/synaptor/proc/tasks_w_io.py
+++ b/synaptor/proc/tasks_w_io.py
@@ -332,7 +332,10 @@ def match_continuations_task(
 
 @queueable
 def seg_graph_cc_task(
-    storagestr: str, num_merge_tasks: int, timing_tag: Optional[str] = None
+    storagestr: str,
+    num_merge_tasks: int,
+    timing_tag: Optional[str] = None,
+    enforce_overlaps: Optional[bool] = False,
 ) -> None:
 
     start_time = time.time()
@@ -345,7 +348,15 @@ def seg_graph_cc_task(
         "Reading all unique seg ids", taskio.read_all_unique_seg_ids, storagestr
     )
 
-    seg_merge_df = tasks.seg_graph_cc_task(graph_edges, num_merge_tasks, all_ids)
+    overlap_map = None
+    if enforce_overlaps:
+        overlap_map = timed(
+            "Reading seg overlap map", taskio.read_seg_overlap_map, storagestr
+        )
+
+    seg_merge_df = tasks.seg_graph_cc_task(
+        graph_edges, num_merge_tasks, all_ids, overlap_map=overlap_map
+    )
 
     timed("Writing seg merge_map", taskio.write_seg_merge_map, seg_merge_df, storagestr)
 


### PR DESCRIPTION
`BigInteger` only supports 2^63-1 ... but it seems we do this everywhere at the moment, so it must be fine?